### PR TITLE
Add light/dark theme switch to web UI

### DIFF
--- a/web/frontend/help.html
+++ b/web/frontend/help.html
@@ -4,71 +4,140 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MoRDor Syntax Reference</title>
+    <!-- Apply the saved theme before first paint to avoid a flash -->
+    <script>
+        (function () {
+            try {
+                var t = localStorage.getItem('mordor-theme');
+                if (!t) {
+                    t = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches
+                        ? 'light' : 'dark';
+                }
+                document.documentElement.setAttribute('data-theme', t);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            }
+        })();
+    </script>
     <style>
+        :root {
+            --bg: #1e1e1e;
+            --bg-elev: #252526;
+            --bg-elev2: #2d2d30;
+            --bg-hover: #323233;
+            --border: #3e3e42;
+            --text: #d4d4d4;
+            --text-strong: #cccccc;
+            --text-muted: #6a6a6a;
+            --accent: #0e639c;
+            --teal: #4ec9b0;
+            --yellow: #dcdcaa;
+            --syn-string: #ce9178;
+            --syn-keyword: #569cd6;
+            --syn-number: #b5cea8;
+            --syn-comment: #6a9955;
+            --syn-variable: #9cdcfe;
+            --note-bg: #3c3c1e;
+            --example-bg: #1e1e2e;
+        }
+        :root[data-theme="light"] {
+            --bg: #ffffff;
+            --bg-elev: #f3f3f3;
+            --bg-elev2: #e8e8ea;
+            --bg-hover: #e6e6e8;
+            --border: #d0d0d4;
+            --text: #2b2b2b;
+            --text-strong: #1a1a1a;
+            --text-muted: #6a6a6a;
+            --accent: #0e639c;
+            --teal: #128071;
+            --yellow: #8a6d00;
+            --syn-string: #a31515;
+            --syn-keyword: #0000ff;
+            --syn-number: #098658;
+            --syn-comment: #008000;
+            --syn-variable: #0451a5;
+            --note-bg: #fbf6d8;
+            --example-bg: #eef4fb;
+        }
+        .theme-toggle {
+            position: fixed;
+            top: 1rem;
+            right: 1rem;
+            background: var(--bg-elev);
+            border: 1px solid var(--border);
+            color: var(--text-strong);
+            font-size: 1.1rem;
+            cursor: pointer;
+            padding: 0.5rem 0.6rem;
+            border-radius: 6px;
+            z-index: 100;
+        }
+        .theme-toggle:hover { background: var(--bg-elev2); }
         * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { 
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; 
-            background: #1e1e1e; 
-            color: #d4d4d4; 
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--text); 
             line-height: 1.6;
             padding: 2rem;
         }
         .container { 
             max-width: 1200px; 
             margin: 0 auto; 
-            background: #252526;
-            border: 1px solid #3e3e42;
+            background: var(--bg-elev);
+            border: 1px solid var(--border);
             border-radius: 8px;
         }
         header { 
-            background: #252526; 
-            border-bottom: 2px solid #0e639c; 
+            background: var(--bg-elev); 
+            border-bottom: 2px solid var(--accent); 
             padding: 2rem; 
         }
         header h1 { 
             font-size: 2rem; 
-            color: #cccccc; 
+            color: var(--text-strong); 
             margin-bottom: 0.5rem;
         }
         header p { 
-            color: #6a6a6a; 
+            color: var(--text-muted); 
             font-size: 1.1rem;
         }
         .content { 
             padding: 2rem; 
         }
         h2 { 
-            color: #4ec9b0; 
+            color: var(--teal); 
             font-size: 1.5rem; 
             margin: 2rem 0 1rem 0; 
             padding-bottom: 0.5rem;
-            border-bottom: 1px solid #3e3e42;
+            border-bottom: 1px solid var(--border);
         }
         h3 { 
-            color: #dcdcaa; 
+            color: var(--yellow); 
             font-size: 1.2rem; 
             margin: 1.5rem 0 0.75rem 0; 
         }
         h4 { 
-            color: #ce9178; 
+            color: var(--syn-string); 
             font-size: 1rem; 
             margin: 1rem 0 0.5rem 0; 
         }
         p { 
             margin-bottom: 1rem; 
-            color: #d4d4d4;
+            color: var(--text);
         }
         code { 
-            background: #1e1e1e; 
-            color: #ce9178; 
+            background: var(--bg); 
+            color: var(--syn-string); 
             padding: 0.2rem 0.4rem; 
             border-radius: 3px; 
             font-family: 'Consolas', 'Courier New', monospace;
             font-size: 0.9em;
         }
         pre { 
-            background: #1e1e1e; 
-            border: 1px solid #3e3e42; 
+            background: var(--bg); 
+            border: 1px solid var(--border); 
             border-radius: 4px; 
             padding: 1rem; 
             overflow-x: auto; 
@@ -82,14 +151,14 @@
             padding: 0;
         }
         .syntax-block { 
-            background: #2d2d30; 
-            border-left: 3px solid #0e639c; 
+            background: var(--bg-elev2); 
+            border-left: 3px solid var(--accent); 
             padding: 1rem; 
             margin: 1rem 0;
             border-radius: 4px;
         }
         .syntax-block .title { 
-            color: #569cd6; 
+            color: var(--syn-keyword); 
             font-weight: bold; 
             margin-bottom: 0.5rem;
         }
@@ -97,33 +166,33 @@
             width: 100%; 
             border-collapse: collapse; 
             margin: 1rem 0;
-            background: #2d2d30;
+            background: var(--bg-elev2);
             border-radius: 4px;
             overflow: hidden;
         }
         th, td { 
             padding: 0.75rem; 
             text-align: left; 
-            border-bottom: 1px solid #3e3e42;
+            border-bottom: 1px solid var(--border);
         }
         th { 
-            background: #1e1e1e; 
-            color: #4ec9b0; 
+            background: var(--bg); 
+            color: var(--teal); 
             font-weight: 600;
         }
         tr:last-child td { 
             border-bottom: none; 
         }
         tr:hover { 
-            background: #323233; 
+            background: var(--bg-hover); 
         }
-        .keyword { color: #569cd6; }
-        .string { color: #ce9178; }
-        .number { color: #b5cea8; }
-        .operator { color: #d4d4d4; }
-        .comment { color: #6a9955; }
-        .function { color: #dcdcaa; }
-        .variable { color: #9cdcfe; }
+        .keyword { color: var(--syn-keyword); }
+        .string { color: var(--syn-string); }
+        .number { color: var(--syn-number); }
+        .operator { color: var(--text); }
+        .comment { color: var(--syn-comment); }
+        .function { color: var(--yellow); }
+        .variable { color: var(--syn-variable); }
         ul, ol { 
             margin: 1rem 0 1rem 2rem; 
         }
@@ -131,37 +200,37 @@
             margin-bottom: 0.5rem; 
         }
         .note { 
-            background: #3c3c1e; 
-            border-left: 3px solid #dcdcaa; 
+            background: var(--note-bg); 
+            border-left: 3px solid var(--yellow); 
             padding: 1rem; 
             margin: 1rem 0;
             border-radius: 4px;
         }
         .note strong { 
-            color: #dcdcaa; 
+            color: var(--yellow); 
         }
         .example { 
-            background: #1e1e2e; 
-            border-left: 3px solid #4ec9b0; 
+            background: var(--example-bg); 
+            border-left: 3px solid var(--teal); 
             padding: 1rem; 
             margin: 1rem 0;
             border-radius: 4px;
         }
         .example-title { 
-            color: #4ec9b0; 
+            color: var(--teal); 
             font-weight: bold; 
             margin-bottom: 0.5rem;
         }
         .toc { 
-            background: #2d2d30; 
-            border: 1px solid #3e3e42; 
+            background: var(--bg-elev2); 
+            border: 1px solid var(--border); 
             border-radius: 4px; 
             padding: 1.5rem; 
             margin: 1rem 0 2rem 0;
         }
         .toc h3 { 
             margin-top: 0; 
-            color: #dcdcaa;
+            color: var(--yellow);
         }
         .toc ul { 
             list-style: none; 
@@ -171,11 +240,11 @@
             margin: 0.5rem 0; 
         }
         .toc a { 
-            color: #4ec9b0; 
+            color: var(--teal); 
             text-decoration: none; 
         }
         .toc a:hover { 
-            color: #5fd4b8; 
+            color: var(--teal); 
             text-decoration: underline; 
         }
         .section { 
@@ -184,6 +253,7 @@
     </style>
 </head>
 <body>
+    <button id="theme-toggle-btn" class="theme-toggle" title="Toggle light/dark theme" aria-label="Toggle light/dark theme">🌙</button>
     <div class="container">
         <header>
             <h1>🔮 MoRDor Syntax Reference</h1>
@@ -1090,5 +1160,23 @@ r2 := fadd(normal, relaxed, relaxed, y, -1);</code></pre>
             </section>
         </div>
     </div>
+    <script>
+        (function () {
+            const btn = document.getElementById('theme-toggle-btn');
+            const root = document.documentElement;
+            const syncIcon = () => {
+                const isLight = root.getAttribute('data-theme') === 'light';
+                btn.textContent = isLight ? '🌙' : '☀️';
+                btn.title = isLight ? 'Switch to dark theme' : 'Switch to light theme';
+            };
+            syncIcon();
+            btn.addEventListener('click', () => {
+                const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+                root.setAttribute('data-theme', next);
+                try { localStorage.setItem('mordor-theme', next); } catch (e) {}
+                syncIcon();
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/web/frontend/index.html
+++ b/web/frontend/index.html
@@ -4,6 +4,21 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MoRDor - Weak Memory Semantics</title>
+    <!-- Apply the saved theme before first paint to avoid a flash -->
+    <script>
+        (function () {
+            try {
+                var t = localStorage.getItem('mordor-theme');
+                if (!t) {
+                    t = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches
+                        ? 'light' : 'dark';
+                }
+                document.documentElement.setAttribute('data-theme', t);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            }
+        })();
+    </script>
     <script src="https://unpkg.com/cytoscape@3.28.1/dist/cytoscape.min.js"></script>
     <script src="https://unpkg.com/layout-base@2.0.1/layout-base.js"></script>
     <script src="https://unpkg.com/cose-base@2.2.0/cose-base.js"></script>
@@ -28,6 +43,7 @@
         <header>
             <h1>MoRDor - Weak Memory Semantics</h1>
             <div class="header-controls">
+                <button id="theme-toggle-btn" class="theme-toggle" title="Toggle light/dark theme" aria-label="Toggle light/dark theme">🌙</button>
                 <button id="test-runner-btn" class="btn-secondary" title="Test Runner">🧪 Tests</button>
                 <button id="settings-btn" class="settings-icon" title="Settings">⚙️</button>
                 <div class="split-button">
@@ -57,10 +73,10 @@
                                 📁 Open
                             </label>
                         </div>
-                        <button id="share-btn" class="btn-secondary" title="Generate shareable URL" style="padding:0.3rem 0.6rem; background:#3c3c3c; border:1px solid #555; color:#d4d4d4; border-radius:4px; cursor:pointer; margin-right:0.5rem;">
+                        <button id="share-btn" class="btn-secondary" title="Generate shareable URL" style="padding:0.3rem 0.6rem; background:var(--control-bg); border:1px solid var(--border-strong); color:var(--text); border-radius:4px; cursor:pointer; margin-right:0.5rem;">
                             🔗 Share
                         </button>
-                        <select id="examples" style="padding:0.3rem; background:#3c3c3c; border:1px solid #555; color:#d4d4d4; border-radius:4px;">
+                        <select id="examples" style="padding:0.3rem; background:var(--control-bg); border:1px solid var(--border-strong); color:var(--text); border-radius:4px;">
                             <option value="">-- Select Example --</option>
                             <option value="sb">Store Buffering (SB)</option>
                             <option value="mp">Message Passing (MP)</option>
@@ -192,7 +208,7 @@
             </div>
             <div class="modal-body">
                 <div class="setting-group">
-                    <h3 style="color: #cccccc; font-size: 1rem; margin-bottom: 1rem; border-bottom: 1px solid #3e3e42; padding-bottom: 0.5rem;">Loop Semantics</h3>
+                    <h3 style="color: var(--text-strong); font-size: 1rem; margin-bottom: 1rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Loop Semantics</h3>
                     <div class="setting-item">
                         <label>
                             <input type="radio" name="loop-semantics" id="step-counter-semantics" value="step-counter" checked />
@@ -202,7 +218,7 @@
                     <div class="setting-item" style="margin-left: 1.5rem; margin-top: 0.5rem;">
                         <label style="display: flex; align-items: center; gap: 0.5rem;">
                             <span>Loop unravellings:</span>
-                            <input type="number" id="step-counter" value="2" min="1" max="100" style="width: 70px; padding: 0.4rem; background: #3c3c3c; border: 1px solid #555; color: #d4d4d4; border-radius: 4px; font-size: 0.9rem;" />
+                            <input type="number" id="step-counter" value="2" min="1" max="100" style="width: 70px; padding: 0.4rem; background: var(--control-bg); border: 1px solid var(--border-strong); color: var(--text); border-radius: 4px; font-size: 0.9rem;" />
                         </label>
                     </div>
                     <div class="setting-item" style="margin-top: 0.75rem;">
@@ -214,11 +230,11 @@
                 </div>
                 
                 <div class="setting-group" style="margin-top: 1.5rem;">
-                    <h3 style="color: #cccccc; font-size: 1rem; margin-bottom: 1rem; border-bottom: 1px solid #3e3e42; padding-bottom: 0.5rem;">Memory Model</h3>
+                    <h3 style="color: var(--text-strong); font-size: 1rem; margin-bottom: 1rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Memory Model</h3>
                     <div class="setting-item">
                         <label style="display: flex; align-items: center; gap: 0.5rem;">
                             <span>Weak memory model:</span>
-                            <select id="memory-model" style="padding: 0.4rem; background: #3c3c3c; border: 1px solid #555; color: #d4d4d4; border-radius: 4px; font-size: 0.9rem;">
+                            <select id="memory-model" style="padding: 0.4rem; background: var(--control-bg); border: 1px solid var(--border-strong); color: var(--text); border-radius: 4px; font-size: 0.9rem;">
                                 <option value="rc11">RC11</option>
                                 <option value="smrd" selected>SMRD</option>
                             </select>
@@ -227,7 +243,7 @@
                 </div>
 
                 <div class="setting-group" style="margin-top: 1.5rem;">
-                    <h3 style="color: #cccccc; font-size: 1rem; margin-bottom: 1rem; border-bottom: 1px solid #3e3e42; padding-bottom: 0.5rem;">Execution Filtering</h3>
+                    <h3 style="color: var(--text-strong); font-size: 1rem; margin-bottom: 1rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem;">Execution Filtering</h3>
                     <div class="setting-item">
                         <label>
                             <input type="checkbox" id="show-uaf" />
@@ -261,9 +277,28 @@
     <!-- Initialize the application -->
     <script>
         window._graphVisualizer = new GraphVisualizer();
-        
+
         // Initialize Test Runner
         const testRunner = new TestRunner();
+
+        // Light/dark theme toggle
+        (function () {
+            const btn = document.getElementById('theme-toggle-btn');
+            const root = document.documentElement;
+            const syncIcon = () => {
+                const isLight = root.getAttribute('data-theme') === 'light';
+                // show the icon for the theme you'd switch *to*
+                btn.textContent = isLight ? '🌙' : '☀️';
+                btn.title = isLight ? 'Switch to dark theme' : 'Switch to light theme';
+            };
+            syncIcon();
+            btn.addEventListener('click', () => {
+                const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+                root.setAttribute('data-theme', next);
+                try { localStorage.setItem('mordor-theme', next); } catch (e) {}
+                syncIcon();
+            });
+        })();
         
         // Load program from URL hash if present (e.g. #program=...)
         const hashParams = new URLSearchParams(window.location.hash.slice(1));

--- a/web/frontend/static/css/mordor.css
+++ b/web/frontend/static/css/mordor.css
@@ -1,18 +1,119 @@
+/* ===== Theme palette =====
+   Dark is the default; [data-theme="light"] on <html> overrides it.
+   All chrome colours reference these variables so the light/dark
+   toggle only has to flip this block. */
+:root {
+    --bg: #1e1e1e;
+    --bg-elev: #252526;
+    --bg-elev2: #2d2d30;
+    --bg-hover: #2a2d2e;
+    --badge-bg: #333333;
+    --control-bg: #3c3c3c;
+    --control-hover: #505050;
+    --border: #3e3e42;
+    --border-strong: #555555;
+    --text: #d4d4d4;
+    --text-strong: #cccccc;
+    --text-muted: #6a6a6a;
+    --text-faint: #858585;
+    --text-hi: #ffffff;
+    --accent: #0e639c;
+    --accent-hover: #1177bb;
+    --accent-active: #0d5a8f;
+    --on-accent: #ffffff;
+    --teal: #4ec9b0;
+    --green: #89d185;
+    --red: #f48771;
+    --yellow: #dcdcaa;
+    --orange: #ffa500;
+    --syn-comment: #6a9955;
+    --syn-keyword: #569cd6;
+    --syn-string: #ce9178;
+    --syn-number: #b5cea8;
+    --syn-function: #dcdcaa;
+    --panel-translucent: rgba(37, 37, 38, 0.95);
+    --sel: rgba(14, 99, 156, 0.3);
+    /* red-tinted surfaces used by the use-after-free panel */
+    --red-bg: #2a1a1a;
+    --red-bg-hover: #3a1f1f;
+    --red-border: #6b2020;
+    --red-bright: #ff6b6b;
+    --red-text: #d4a0a0;
+}
+
+:root[data-theme="light"] {
+    --bg: #ffffff;
+    --bg-elev: #f3f3f3;
+    --bg-elev2: #e8e8ea;
+    --bg-hover: #e6e6e8;
+    --badge-bg: #dddddd;
+    --control-bg: #eaeaea;
+    --control-hover: #d8d8d8;
+    --border: #d0d0d4;
+    --border-strong: #b4b4ba;
+    --text: #2b2b2b;
+    --text-strong: #1a1a1a;
+    --text-muted: #6a6a6a;
+    --text-faint: #888888;
+    --text-hi: #000000;
+    --accent: #0e639c;
+    --accent-hover: #1177bb;
+    --accent-active: #0d5a8f;
+    --on-accent: #ffffff;
+    --teal: #128071;
+    --green: #2f8a3e;
+    --red: #c0392b;
+    --yellow: #8a6d00;
+    --orange: #b06a00;
+    --syn-comment: #008000;
+    --syn-keyword: #0000ff;
+    --syn-string: #a31515;
+    --syn-number: #098658;
+    --syn-function: #795e26;
+    --panel-translucent: rgba(243, 243, 243, 0.95);
+    --sel: rgba(14, 99, 156, 0.2);
+    --red-bg: #fbeaea;
+    --red-bg-hover: #f6dcdc;
+    --red-border: #e0a0a0;
+    --red-bright: #c0392b;
+    --red-text: #8a4040;
+}
+
+/* Theme toggle button in the header */
+.theme-toggle {
+    background: none;
+    border: none;
+    color: var(--text-strong);
+    font-size: 1.2rem;
+    cursor: pointer;
+    padding: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition: background 0.2s, color 0.2s;
+}
+
+.theme-toggle:hover {
+    color: var(--text-hi);
+    background: var(--bg-elev2);
+}
+
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #1e1e1e; color: #d4d4d4; height: 100vh; overflow: hidden; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--text); height: 100vh; overflow: hidden; }
 .container { display: flex; flex-direction: column; height: 100vh; }
-header { background: #252526; border-bottom: 1px solid #3e3e42; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
-header h1 { font-size: 1.5rem; color: #cccccc; }
+header { background: var(--bg-elev); border-bottom: 1px solid var(--border); padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+header h1 { font-size: 1.5rem; color: var(--text-strong); }
 .header-controls { display: flex; gap: 1rem; align-items: center; }
 .main-content { display: flex; flex: 1; overflow: hidden; }
-.panel { display: flex; flex-direction: column; background: #1e1e1e; border: 1px solid #3e3e42; position: relative; min-width: 200px; }
+.panel { display: flex; flex-direction: column; background: var(--bg); border: 1px solid var(--border); position: relative; min-width: 200px; }
 .panel:first-child { flex: 1 20%; }
 .panel:nth-child(3) { flex: 1 1 60%; }
-.resizer { width: 5px; background: #3e3e42; cursor: col-resize; flex-shrink: 0; position: relative; }
-.resizer:hover { background: #0e639c; }
-.resizer:active { background: #1177bb; }
-.panel-header { background: #252526; border-bottom: 1px solid #3e3e42; padding: 0.75rem 1rem; display: flex; justify-content: space-between; align-items: center; }
-.panel-header h2 { font-size: 1rem; color: #cccccc; }
+.resizer { width: 5px; background: var(--border); cursor: col-resize; flex-shrink: 0; position: relative; }
+.resizer:hover { background: var(--accent); }
+.resizer:active { background: var(--accent-hover); }
+.panel-header { background: var(--bg-elev); border-bottom: 1px solid var(--border); padding: 0.75rem 1rem; display: flex; justify-content: space-between; align-items: center; }
+.panel-header h2 { font-size: 1rem; color: var(--text-strong); }
 
 /* File input button */
 .file-input-wrapper {
@@ -27,9 +128,9 @@ header h1 { font-size: 1.5rem; color: #cccccc; }
 }
 
 .file-input-label {
-    background: #3c3c3c;
-    color: #cccccc;
-    border: 1px solid #555;
+    background: var(--control-bg);
+    color: var(--text-strong);
+    border: 1px solid var(--border-strong);
     padding: 0.3rem 0.75rem;
     border-radius: 4px;
     cursor: pointer;
@@ -41,7 +142,7 @@ header h1 { font-size: 1.5rem; color: #cccccc; }
 }
 
 .file-input-label:hover {
-    background: #505050;
+    background: var(--control-hover);
 }
 
 .panel-header-controls {
@@ -55,7 +156,7 @@ header h1 { font-size: 1.5rem; color: #cccccc; }
     flex: 1; 
     overflow: hidden; 
     position: relative;
-    background: #1e1e1e;
+    background: var(--bg);
 }
 
 .editor-wrapper {
@@ -116,7 +217,7 @@ header h1 { font-size: 1.5rem; color: #cccccc; }
     border: none !important;
     resize: none;
     color: transparent;
-    caret-color: #d4d4d4;
+    caret-color: var(--text);
     tab-size: 4;
     z-index: 1;
     /* horizontal + vertical scroll; no wrapping */
@@ -131,12 +232,12 @@ header h1 { font-size: 1.5rem; color: #cccccc; }
 }
 
 #litmus-input::selection {
-    background: rgba(14, 99, 156, 0.3);
+    background: var(--sel);
 }
 
 /* Override PrismJS colors for dark theme */
 pre[class*="language-"] {
-    background: #1e1e1e !important;
+    background: var(--bg) !important;
     margin: 0 !important;
     padding: 0 !important;
     font-family: 'Consolas', 'Courier New', monospace !important;
@@ -150,7 +251,7 @@ pre[class*="language-"] {
 
 code[class*="language-"] {
     background: transparent !important;
-    color: #d4d4d4 !important;
+    color: var(--text) !important;
     font-family: 'Consolas', 'Courier New', monospace !important;
     font-size: 0.95rem !important;
     line-height: 1.5 !important;
@@ -160,13 +261,13 @@ code[class*="language-"] {
     tab-size: 4 !important;
 }
 
-.token.comment { color: #6a9955; }
-.token.keyword { color: #569cd6; }
-.token.string { color: #ce9178; }
-.token.number { color: #b5cea8; }
-.token.operator { color: #d4d4d4; }
-.token.punctuation { color: #d4d4d4; }
-.token.function { color: #dcdcaa; }
+.token.comment { color: var(--syn-comment); }
+.token.keyword { color: var(--syn-keyword); }
+.token.string { color: var(--syn-string); }
+.token.number { color: var(--syn-number); }
+.token.operator { color: var(--text); }
+.token.punctuation { color: var(--text); }
+.token.function { color: var(--syn-function); }
 
 /* Line numbers styling */
 pre.line-numbers {
@@ -188,7 +289,7 @@ pre.line-numbers > code {
     /* Prism plugin sets left automatically; keep width/style only */
     width: 3em;
     letter-spacing: -1px;
-    border-right: 1px solid #3e3e42;
+    border-right: 1px solid var(--border);
     user-select: none;
     padding-right: 0.5rem;
     padding-left: 0.5rem;
@@ -205,7 +306,7 @@ pre.line-numbers > code {
 
 .line-numbers-rows > span:before {
     content: counter(linenumber);
-    color: #6a6a6a;
+    color: var(--text-muted);
     display: block;
     text-align: right;
 }
@@ -213,50 +314,50 @@ pre.line-numbers > code {
 /* Carousel styles */
 .carousel-container { flex: 1; position: relative; display: none; }
 .carousel-container.active { display: flex; flex-direction: column; }
-#cy { flex: 1; background: #1e1e1e; }
+#cy { flex: 1; background: var(--bg); }
 
 .carousel-controls { position: absolute; top: 50%; left: 0; right: 0; display: flex; justify-content: space-between; align-items: center; pointer-events: none; z-index: 200; transform: translateY(-50%); padding: 0 10px; }
-.carousel-btn { pointer-events: all; background: rgba(37, 37, 38, 0.95); border: 1px solid #3e3e42; color: #cccccc; width: 40px; height: 40px; border-radius: 50%; cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 1.2rem; transition: all 0.2s; }
-.carousel-btn:hover:not(:disabled) { background: #505050; transform: scale(1.1); }
+.carousel-btn { pointer-events: all; background: var(--panel-translucent); border: 1px solid var(--border); color: var(--text-strong); width: 40px; height: 40px; border-radius: 50%; cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 1.2rem; transition: all 0.2s; }
+.carousel-btn:hover:not(:disabled) { background: var(--control-hover); transform: scale(1.1); }
 .carousel-btn:disabled { opacity: 0.3; cursor: not-allowed; }
 
-.carousel-indicator { position: absolute; top: 10px; left: 50%; transform: translateX(-50%); background: rgba(37, 37, 38, 0.95); border: 1px solid #3e3e42; border-radius: 20px; padding: 0.5rem 1rem; font-size: 0.9rem; color: #cccccc; z-index: 100; }
+.carousel-indicator { position: absolute; top: 10px; left: 50%; transform: translateX(-50%); background: var(--panel-translucent); border: 1px solid var(--border); border-radius: 20px; padding: 0.5rem 1rem; font-size: 0.9rem; color: var(--text-strong); z-index: 100; }
 
-.btn-primary { background: #0e639c; color: #ffffff; border: 1px solid #0e639c; padding: 0.5rem 1rem; border-radius: 4px; cursor: pointer; font-size: 0.9rem; transition: background 0.2s; }
-.btn-primary:hover { background: #1177bb; border-color: #1177bb; }
-.btn-primary:active { background: #0d5a8f; }
+.btn-primary { background: var(--accent); color: var(--on-accent); border: 1px solid var(--accent); padding: 0.5rem 1rem; border-radius: 4px; cursor: pointer; font-size: 0.9rem; transition: background 0.2s; }
+.btn-primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+.btn-primary:active { background: var(--accent-active); }
 
-.empty-state { flex: 1; display: flex; align-items: center; justify-content: center; color: #6a6a6a; font-size: 1.1rem; }
-.status { font-size: 0.9rem; color: #6a6a6a; }
-.status.error { color: #f48771; }
-.status.success { color: #4ec9b0; }
+.empty-state { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--text-muted); font-size: 1.1rem; }
+.status { font-size: 0.9rem; color: var(--text-muted); }
+.status.error { color: var(--red); }
+.status.success { color: var(--teal); }
 
 .graph-controls { position: absolute; bottom: 10px; left: 10px; display: none; gap: 0.5rem; z-index: 100; }
 .graph-controls.active { display: flex; }
-.graph-controls select { padding: 0.4rem 0.6rem; background: rgba(37, 37, 38, 0.95); border: 1px solid #3e3e42; color: #cccccc; border-radius: 4px; font-size: 0.85rem; cursor: pointer; }
+.graph-controls select { padding: 0.4rem 0.6rem; background: var(--panel-translucent); border: 1px solid var(--border); color: var(--text-strong); border-radius: 4px; font-size: 0.85rem; cursor: pointer; }
 .layout-dropdown { position: relative; display: inline-block; }
-.layout-btn { background: rgba(37, 37, 38, 0.95) !important; border: 1px solid #3e3e42 !important; color: #cccccc !important; padding: 0.4rem 0.6rem !important; border-radius: 4px !important; font-size: 0.85rem !important; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
-.layout-btn:hover { background: #505050 !important; }
-.layout-dropdown-content { display: none; position: fixed; background: #2d2d30; border: 1px solid #3e3e42; border-radius: 4px; box-shadow: 0 6px 16px rgba(0,0,0,0.5); z-index: 9999; min-width: 150px; }
+.layout-btn { background: var(--panel-translucent) !important; border: 1px solid var(--border) !important; color: var(--text-strong) !important; padding: 0.4rem 0.6rem !important; border-radius: 4px !important; font-size: 0.85rem !important; cursor: pointer; white-space: nowrap; transition: background 0.2s; }
+.layout-btn:hover { background: var(--control-hover) !important; }
+.layout-dropdown-content { display: none; position: fixed; background: var(--bg-elev2); border: 1px solid var(--border); border-radius: 4px; box-shadow: 0 6px 16px rgba(0,0,0,0.5); z-index: 9999; min-width: 150px; }
 .layout-dropdown.open .layout-dropdown-content { display: block; }
-.layout-option { padding: 8px 12px; font-size: 13px; color: #d4d4d4; cursor: pointer; }
-.layout-option:hover { background: #3e3e42; }
-.layout-option.active { color: #4ec9b0; }
-.graph-controls button { padding: 0.4rem 0.8rem; background: rgba(37, 37, 38, 0.95); border: 1px solid #3e3e42; color: #cccccc; border-radius: 4px; font-size: 0.85rem; cursor: pointer; transition: all 0.2s; }
-.graph-controls button:hover { background: #505050; }
+.layout-option { padding: 8px 12px; font-size: 13px; color: var(--text); cursor: pointer; }
+.layout-option:hover { background: var(--border); }
+.layout-option.active { color: var(--teal); }
+.graph-controls button { padding: 0.4rem 0.8rem; background: var(--panel-translucent); border: 1px solid var(--border); color: var(--text-strong); border-radius: 4px; font-size: 0.85rem; cursor: pointer; transition: all 0.2s; }
+.graph-controls button:hover { background: var(--control-hover); }
 
-.graph-stats { position: absolute; bottom: 10px; right: 10px; background: rgba(37, 37, 38, 0.95); border: 1px solid #3e3e42; border-radius: 6px; padding: 0.75rem 1rem; font-size: 0.85rem; display: none; flex-direction: column; gap: 0.4rem; z-index: 100; }
+.graph-stats { position: absolute; bottom: 10px; right: 10px; background: var(--panel-translucent); border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem 1rem; font-size: 0.85rem; display: none; flex-direction: column; gap: 0.4rem; z-index: 100; }
 .graph-stats.active { display: flex; }
 .graph-stats div { display: flex; justify-content: space-between; gap: 1rem; }
-.graph-stats strong { color: #cccccc; }
-.graph-stats span { color: #4ec9b0; }
+.graph-stats strong { color: var(--text-strong); }
+.graph-stats span { color: var(--teal); }
 
 .execution-info {
     position: absolute;
     top: 70px;
     left: 10px;
-    background: rgba(37, 37, 38, 0.95);
-    border: 1px solid #3e3e42;
+    background: var(--panel-translucent);
+    border: 1px solid var(--border);
     border-radius: 6px;
     padding: 0.75rem 1rem;
     font-size: 0.85rem;
@@ -277,11 +378,11 @@ pre.line-numbers > code {
 }
 
 .execution-info strong {
-    color: #cccccc;
+    color: var(--text-strong);
 }
 
 .execution-info span {
-    color: #4ec9b0;
+    color: var(--teal);
 }
 
 /* Modal Styles */
@@ -303,8 +404,8 @@ pre.line-numbers > code {
 }
 
 .modal-content {
-    background: #252526;
-    border: 1px solid #3e3e42;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
     border-radius: 6px;
     width: 90%;
     max-width: 500px;
@@ -316,18 +417,18 @@ pre.line-numbers > code {
     justify-content: space-between;
     align-items: center;
     padding: 1rem 1.5rem;
-    border-bottom: 1px solid #3e3e42;
+    border-bottom: 1px solid var(--border);
 }
 
 .modal-header h2 {
     font-size: 1.2rem;
-    color: #cccccc;
+    color: var(--text-strong);
 }
 
 .modal-close {
     background: none;
     border: none;
-    color: #cccccc;
+    color: var(--text-strong);
     font-size: 1.5rem;
     cursor: pointer;
     line-height: 1;
@@ -335,7 +436,7 @@ pre.line-numbers > code {
 }
 
 .modal-close:hover {
-    color: #ffffff;
+    color: var(--text-hi);
 }
 
 .modal-body {
@@ -350,7 +451,7 @@ pre.line-numbers > code {
     display: flex;
     align-items: center;
     cursor: pointer;
-    color: #d4d4d4;
+    color: var(--text);
     font-size: 0.95rem;
 }
 
@@ -359,7 +460,7 @@ pre.line-numbers > code {
     height: 18px;
     margin-right: 0.75rem;
     cursor: pointer;
-    accent-color: #0e639c;
+    accent-color: var(--accent);
 }
 
 .setting-item input[type="radio"] {
@@ -367,7 +468,7 @@ pre.line-numbers > code {
     height: 18px;
     margin-right: 0.75rem;
     cursor: pointer;
-    accent-color: #0e639c;
+    accent-color: var(--accent);
 }
 
 .setting-group {
@@ -375,10 +476,10 @@ pre.line-numbers > code {
 }
 
 .setting-group h3 {
-    color: #cccccc;
+    color: var(--text-strong);
     font-size: 1rem;
     margin-bottom: 1rem;
-    border-bottom: 1px solid #3e3e42;
+    border-bottom: 1px solid var(--border);
     padding-bottom: 0.5rem;
 }
 
@@ -387,23 +488,23 @@ pre.line-numbers > code {
     justify-content: flex-end;
     gap: 0.75rem;
     padding: 1rem 1.5rem;
-    border-top: 1px solid #3e3e42;
+    border-top: 1px solid var(--border);
 }
 
 .btn-secondary {
-    background: #3c3c3c;
-    color: #cccccc;
+    background: var(--control-bg);
+    color: var(--text-strong);
     padding: 0.5rem 1rem;
 }
 
 .btn-secondary:hover {
-    background: #505050;
+    background: var(--control-hover);
 }
 
 .settings-icon {
     background: none;
     border: none;
-    color: #cccccc;
+    color: var(--text-strong);
     font-size: 1.2rem;
     cursor: pointer;
     padding: 0.5rem;
@@ -413,7 +514,7 @@ pre.line-numbers > code {
 }
 
 .settings-icon:hover {
-    color: #ffffff;
+    color: var(--text-hi);
 }
 
 /* Source code highlight overlay */
@@ -433,49 +534,49 @@ pre.line-numbers > code {
 }
 
 /* Log panel styles */
-#log { background: #252526; border-top: 1px solid #3e3e42; height: 150px; overflow-y: auto; padding: 0.5rem 1rem; font-family: 'Consolas', monospace; font-size: 0.85rem; }
+#log { background: var(--bg-elev); border-top: 1px solid var(--border); height: 150px; overflow-y: auto; padding: 0.5rem 1rem; font-family: 'Consolas', monospace; font-size: 0.85rem; }
 .log-entry { padding: 0.25rem 0; }
-.log-time { color: #6a6a6a; margin-right: 0.5rem; }
-.error { color: #f48771; }
-.success { color: #89d185; }
-.info { color: #4ec9b0; }
+.log-time { color: var(--text-muted); margin-right: 0.5rem; }
+.error { color: var(--red); }
+.success { color: var(--green); }
+.info { color: var(--teal); }
 
 /* Sidebar styles */
 .sidebar {
     display: flex;
     flex-direction: column;
-    background: #1e1e1e;
-    border: 1px solid #3e3e42;
+    background: var(--bg);
+    border: 1px solid var(--border);
     border-left: none;
     min-width: 200px;
     flex: 1 1 20%;
 }
 
 .sidebar-header {
-    background: #252526;
-    border-bottom: 1px solid #3e3e42;
+    background: var(--bg-elev);
+    border-bottom: 1px solid var(--border);
     padding: 0.75rem 1rem;
 }
 
 .sidebar-header h2 {
     font-size: 1rem;
-    color: #cccccc;
+    color: var(--text-strong);
 }
 
 #resizer-right {
     width: 5px;
-    background: #3e3e42;
+    background: var(--border);
     cursor: col-resize;
     flex-shrink: 0;
     position: relative;
 }
 
 #resizer-right:hover {
-    background: #0e639c;
+    background: var(--accent);
 }
 
 #resizer-right:active {
-    background: #1177bb;
+    background: var(--accent-hover);
 }
 
 /* Accordion styles */
@@ -486,7 +587,7 @@ pre.line-numbers > code {
 }
 
 .accordion-item {
-    border-bottom: 1px solid #3e3e42;
+    border-bottom: 1px solid var(--border);
     display: flex;
     flex-direction: column;
     min-height: 0;
@@ -498,9 +599,9 @@ pre.line-numbers > code {
 
 .accordion-header {
     width: 100%;
-    background: #252526;
+    background: var(--bg-elev);
     border: none;
-    color: #cccccc;
+    color: var(--text-strong);
     padding: 0.75rem 1rem;
     text-align: left;
     cursor: pointer;
@@ -512,7 +613,7 @@ pre.line-numbers > code {
 }
 
 .accordion-header:hover {
-    background: #2d2d30;
+    background: var(--bg-elev2);
 }
 
 .accordion-icon {
@@ -528,7 +629,7 @@ pre.line-numbers > code {
     flex: 0 0 0;
     overflow: hidden;
     transition: flex 0.3s ease;
-    background: #1e1e1e;
+    background: var(--bg);
     display: flex;
     flex-direction: column;
 }
@@ -540,20 +641,20 @@ pre.line-numbers > code {
 
 .accordion-content p {
     padding: 1rem;
-    color: #d4d4d4;
+    color: var(--text);
     font-size: 0.9rem;
 }
 
 /* Assertion results styling */
 .assertion-item {
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid #3e3e42;
+    border-bottom: 1px solid var(--border);
     cursor: pointer;
     transition: background 0.2s;
 }
 
 .assertion-item:hover {
-    background: #2d2d30;
+    background: var(--bg-elev2);
 }
 
 .assertion-item:last-child {
@@ -574,32 +675,32 @@ pre.line-numbers > code {
 }
 
 .assertion-type.witnessed {
-    color: #89d185;
+    color: var(--green);
 }
 
 .assertion-type.contradicted {
-    color: #f48771;
+    color: var(--red);
 }
 
 .assertion-type.confirmed {
-    color: #4ec9b0;
+    color: var(--teal);
 }
 
 .assertion-type.refuted {
-    color: #ffa500;
+    color: var(--orange);
 }
 
 .assertion-exec-id {
     font-size: 0.8rem;
-    color: #6a6a6a;
+    color: var(--text-muted);
 }
 
 .assertion-expr {
     font-family: 'Consolas', 'Courier New', monospace;
     font-size: 0.85rem;
-    color: #d4d4d4;
+    color: var(--text);
     padding: 0.5rem;
-    background: #1e1e1e;
+    background: var(--bg);
     border-radius: 3px;
     margin: 0.5rem 0;
     white-space: pre-wrap;
@@ -620,22 +721,22 @@ pre.line-numbers > code {
 }
 
 .assertion-result.true {
-    color: #89d185;
+    color: var(--green);
 }
 
 .assertion-result.false {
-    color: #f48771;
+    color: var(--red);
 }
 
 .assertion-memberships {
     margin-top: 0.75rem;
     padding-top: 0.75rem;
-    border-top: 1px solid #3e3e42;
+    border-top: 1px solid var(--border);
 }
 
 .assertion-memberships-title {
     font-size: 0.8rem;
-    color: #cccccc;
+    color: var(--text-strong);
     margin-bottom: 0.5rem;
     font-weight: bold;
 }
@@ -643,7 +744,7 @@ pre.line-numbers > code {
 .membership-item {
     font-size: 0.8rem;
     padding: 0.4rem 0.5rem;
-    background: #1e1e1e;
+    background: var(--bg);
     border-radius: 3px;
     margin: 0.3rem 0;
     display: flex;
@@ -653,13 +754,13 @@ pre.line-numbers > code {
 
 .membership-relation {
     font-family: 'Consolas', 'Courier New', monospace;
-    color: #4ec9b0;
+    color: var(--teal);
     font-weight: bold;
 }
 
 .membership-pair {
     font-family: 'Consolas', 'Courier New', monospace;
-    color: #d4d4d4;
+    color: var(--text);
 }
 
 .membership-result {
@@ -668,17 +769,17 @@ pre.line-numbers > code {
 }
 
 .membership-result.true {
-    color: #89d185;
+    color: var(--green);
 }
 
 .membership-result.false {
-    color: #f48771;
+    color: var(--red);
 }
 
 .assertion-validity {
     padding: 0.75rem 1rem;
-    background: #252526;
-    border-bottom: 1px solid #3e3e42;
+    background: var(--bg-elev);
+    border-bottom: 1px solid var(--border);
     font-size: 0.9rem;
     display: flex;
     align-items: center;
@@ -691,26 +792,26 @@ pre.line-numbers > code {
 }
 
 .assertion-validity.valid {
-    color: #89d185;
+    color: var(--green);
 }
 
 .assertion-validity.invalid {
-    color: #f48771;
+    color: var(--red);
 }
 
 /* Collapsible loop styles */
 .loop-item {
     padding: 0.75rem;
     margin: 0.5rem 0;
-    background: #252526;
-    border: 1px solid #3e3e42;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
     border-radius: 4px;
     cursor: pointer;
     transition: background 0.2s;
 }
 
 .loop-item:hover {
-    background: #2d2d30;
+    background: var(--bg-elev2);
 }
 
 .loop-header {
@@ -721,7 +822,7 @@ pre.line-numbers > code {
 
 .loop-toggle {
     font-size: 0.8rem;
-    color: #6a6a6a;
+    color: var(--text-muted);
     transition: transform 0.2s;
 }
 
@@ -744,14 +845,14 @@ pre.line-numbers > code {
 .episodicity-condition {
     margin: 0.4rem 0;
     padding: 0.4rem;
-    background: #1e1e1e;
+    background: var(--bg);
     border-radius: 3px;
     cursor: pointer;
     transition: background 0.2s;
 }
 
 .episodicity-condition:hover {
-    background: #252526;
+    background: var(--bg-elev);
 }
 
 .condition-header {
@@ -763,7 +864,7 @@ pre.line-numbers > code {
 
 .condition-toggle {
     font-size: 0.7rem;
-    color: #6a6a6a;
+    color: var(--text-muted);
     transition: transform 0.2s;
 }
 
@@ -803,17 +904,17 @@ pre.line-numbers > code {
 }
 
 .split-button-toggle:hover {
-    background: #005a9e;
+    background: var(--accent-hover);
 }
 
 .dropdown-content {
     display: none;
     position: absolute;
-    background-color: #2d2d30;
+    background-color: var(--bg-elev2);
     min-width: 160px;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.4);
     z-index: 1000;
-    border: 1px solid #3e3e42;
+    border: 1px solid var(--border);
     border-radius: 4px;
     margin-top: 2px;
     top: 100%;
@@ -821,7 +922,7 @@ pre.line-numbers > code {
 }
 
 .dropdown-content button {
-    color: #d4d4d4;
+    color: var(--text);
     padding: 10px 16px;
     text-decoration: none;
     display: block;
@@ -835,7 +936,7 @@ pre.line-numbers > code {
 }
 
 .dropdown-content button:hover {
-    background-color: #3e3e42;
+    background-color: var(--border);
 }
 
 .dropdown-content button:first-child {
@@ -857,9 +958,9 @@ pre.line-numbers > code {
 }
 
 .relations-btn {
-    background: #3c3c3c;
-    border: 1px solid #555;
-    color: #d4d4d4;
+    background: var(--control-bg);
+    border: 1px solid var(--border-strong);
+    color: var(--text);
     padding: 0.4rem 0.75rem;
     border-radius: 4px;
     cursor: pointer;
@@ -869,14 +970,14 @@ pre.line-numbers > code {
 }
 
 .relations-btn:hover {
-    background: #4a4a4a;
+    background: var(--control-hover);
 }
 
 .relations-dropdown-content {
     display: none;
     position: fixed;
-    background: #2d2d30;
-    border: 1px solid #3e3e42;
+    background: var(--bg-elev2);
+    border: 1px solid var(--border);
     border-radius: 4px;
     box-shadow: 0 6px 16px rgba(0,0,0,0.5);
     z-index: 9999;
@@ -892,9 +993,9 @@ pre.line-numbers > code {
     align-items: center;
     justify-content: space-between;
     padding: 8px 12px;
-    border-bottom: 1px solid #3e3e42;
+    border-bottom: 1px solid var(--border);
     font-size: 12px;
-    color: #888;
+    color: var(--text-faint);
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
@@ -905,9 +1006,9 @@ pre.line-numbers > code {
 }
 
 .relations-header-actions button {
-    background: #3c3c3c;
-    border: 1px solid #555;
-    color: #aaa;
+    background: var(--control-bg);
+    border: 1px solid var(--border-strong);
+    color: var(--text-muted);
     padding: 2px 7px;
     border-radius: 3px;
     cursor: pointer;
@@ -916,8 +1017,8 @@ pre.line-numbers > code {
 }
 
 .relations-header-actions button:hover {
-    background: #4e4e4e;
-    color: #d4d4d4;
+    background: var(--control-hover);
+    color: var(--text);
 }
 
 #relations-checkboxes {
@@ -935,12 +1036,12 @@ pre.line-numbers > code {
 }
 
 .relation-checkbox-item:hover {
-    background: #3a3a3a;
+    background: var(--bg-hover);
 }
 
 .relation-checkbox-item input[type="checkbox"] {
     cursor: pointer;
-    accent-color: #4ec9b0;
+    accent-color: var(--teal);
     width: 14px;
     height: 14px;
     flex-shrink: 0;
@@ -954,7 +1055,7 @@ pre.line-numbers > code {
 }
 
 .relation-checkbox-item label {
-    color: #d4d4d4;
+    color: var(--text);
     font-size: 13px;
     cursor: pointer;
     flex: 1;

--- a/web/frontend/static/css/test-runner.css
+++ b/web/frontend/static/css/test-runner.css
@@ -18,8 +18,8 @@
 }
 
 .test-modal {
-    background: #252526;
-    border: 1px solid #3e3e42;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
     border-radius: 8px;
     width: 90%;
     max-width: 1200px;
@@ -46,20 +46,20 @@
     justify-content: space-between;
     align-items: center;
     padding: 1rem 1.5rem;
-    border-bottom: 1px solid #3e3e42;
-    background: #2d2d30;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-elev2);
 }
 
 .test-header h2 {
     font-size: 1.3rem;
-    color: #cccccc;
+    color: var(--text-strong);
     margin: 0;
 }
 
 .test-close {
     background: none;
     border: none;
-    color: #cccccc;
+    color: var(--text-strong);
     font-size: 2rem;
     cursor: pointer;
     line-height: 1;
@@ -74,7 +74,7 @@
 }
 
 .test-close:hover {
-    background: #3e3e42;
+    background: var(--border);
 }
 
 .test-toolbar {
@@ -82,8 +82,8 @@
     gap: 0.75rem;
     align-items: center;
     padding: 1rem 1.5rem;
-    border-bottom: 1px solid #3e3e42;
-    background: #1e1e1e;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
 }
 
 .test-stats {
@@ -94,19 +94,19 @@
 }
 
 .test-stats span {
-    color: #d4d4d4;
+    color: var(--text);
 }
 
 .stat-passed {
-    color: #4ec9b0 !important;
+    color: var(--teal) !important;
 }
 
 .stat-failed {
-    color: #f48771 !important;
+    color: var(--red) !important;
 }
 
 .stat-running {
-    color: #dcdcaa !important;
+    color: var(--yellow) !important;
 }
 
 .test-content {
@@ -117,30 +117,30 @@
 
 .test-sidebar {
     width: 300px;
-    border-right: 1px solid #3e3e42;
+    border-right: 1px solid var(--border);
     display: flex;
     flex-direction: column;
-    background: #1e1e1e;
+    background: var(--bg);
 }
 
 .test-search {
     padding: 1rem;
-    border-bottom: 1px solid #3e3e42;
+    border-bottom: 1px solid var(--border);
 }
 
 .test-search input {
     width: 100%;
     padding: 0.5rem;
-    background: #3c3c3c;
-    border: 1px solid #555;
-    color: #d4d4d4;
+    background: var(--control-bg);
+    border: 1px solid var(--border-strong);
+    color: var(--text);
     border-radius: 4px;
     font-size: 0.9rem;
 }
 
 .test-search input:focus {
     outline: none;
-    border-color: #0e639c;
+    border-color: var(--accent);
 }
 
 .test-list {
@@ -162,19 +162,19 @@
     cursor: pointer;
     border-radius: 4px;
     transition: background 0.15s;
-    color: #d4d4d4;
+    color: var(--text);
     font-size: 0.9rem;
 }
 
 .test-dir-header:hover {
-    background: #2a2d2e;
+    background: var(--bg-hover);
 }
 
 .test-dir-toggle {
     font-size: 0.7rem;
     width: 12px;
     text-align: center;
-    color: #858585;
+    color: var(--text-faint);
     flex-shrink: 0;
     transition: transform 0.15s;
 }
@@ -186,20 +186,20 @@
     flex-shrink: 0;
 }
 
-.test-dir-header.test-passed .test-dir-icon { color: #4ec9b0; }
-.test-dir-header.test-failed .test-dir-icon { color: #f48771; }
-.test-dir-header.test-running .test-dir-icon { color: #dcdcaa; }
+.test-dir-header.test-passed .test-dir-icon { color: var(--teal); }
+.test-dir-header.test-failed .test-dir-icon { color: var(--red); }
+.test-dir-header.test-running .test-dir-icon { color: var(--yellow); }
 
 .test-dir-name {
     flex: 1;
     font-weight: 500;
-    color: #cccccc;
+    color: var(--text-strong);
 }
 
 .test-dir-count {
     font-size: 0.75rem;
-    color: #6a6a6a;
-    background: #333;
+    color: var(--text-muted);
+    background: var(--badge-bg);
     padding: 0.1rem 0.4rem;
     border-radius: 8px;
     min-width: 20px;
@@ -219,20 +219,20 @@
 }
 
 .test-item:hover {
-    background: #2a2d2e;
-    border-left-color: #0e639c;
+    background: var(--bg-hover);
+    border-left-color: var(--accent);
 }
 
 .test-item.test-passed {
-    border-left-color: #4ec9b0;
+    border-left-color: var(--teal);
 }
 
 .test-item.test-failed {
-    border-left-color: #f48771;
+    border-left-color: var(--red);
 }
 
 .test-item.test-running {
-    border-left-color: #dcdcaa;
+    border-left-color: var(--yellow);
 }
 
 .test-item-header {
@@ -250,15 +250,15 @@
 }
 
 .test-item.test-passed .test-status-icon {
-    color: #4ec9b0;
+    color: var(--teal);
 }
 
 .test-item.test-failed .test-status-icon {
-    color: #f48771;
+    color: var(--red);
 }
 
 .test-item.test-running .test-status-icon {
-    color: #dcdcaa;
+    color: var(--yellow);
     animation: spin 1s linear infinite;
 }
 
@@ -269,7 +269,7 @@
 
 .test-name {
     flex: 1;
-    color: #d4d4d4;
+    color: var(--text);
     font-size: 0.85rem;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -279,7 +279,7 @@
 .test-run-btn {
     background: none;
     border: none;
-    color: #6a6a6a;
+    color: var(--text-muted);
     padding: 0.1rem 0.3rem;
     border-radius: 3px;
     cursor: pointer;
@@ -293,7 +293,7 @@
 }
 
 .test-run-btn:hover {
-    background: #0e639c;
+    background: var(--accent);
     color: white;
 }
 
@@ -301,14 +301,14 @@
     margin-top: 0.2rem;
     padding-left: 18px;
     font-size: 0.75rem;
-    color: #6a6a6a;
+    color: var(--text-muted);
 }
 
 .test-main {
     flex: 1;
     display: flex;
     flex-direction: column;
-    background: #1e1e1e;
+    background: var(--bg);
     overflow: hidden;
 }
 
@@ -330,13 +330,13 @@
 }
 
 .test-welcome h3 {
-    color: #cccccc;
+    color: var(--text-strong);
     font-size: 1.5rem;
     margin-bottom: 1rem;
 }
 
 .test-welcome p {
-    color: #d4d4d4;
+    color: var(--text);
     font-size: 1rem;
     line-height: 1.6;
 }
@@ -346,14 +346,14 @@
     align-items: center;
     gap: 1rem;
     padding-bottom: 1rem;
-    border-bottom: 1px solid #3e3e42;
+    border-bottom: 1px solid var(--border);
     margin-bottom: 1.5rem;
 }
 
 .btn-back {
-    background: #3c3c3c;
-    color: #cccccc;
-    border: 1px solid #555;
+    background: var(--control-bg);
+    color: var(--text-strong);
+    border: 1px solid var(--border-strong);
     padding: 0.5rem 1rem;
     border-radius: 4px;
     cursor: pointer;
@@ -361,12 +361,12 @@
 }
 
 .btn-back:hover {
-    background: #505050;
+    background: var(--control-hover);
 }
 
 .test-detail-header h3 {
     flex: 1;
-    color: #cccccc;
+    color: var(--text-strong);
     font-size: 1.2rem;
     margin: 0;
 }
@@ -392,7 +392,7 @@
 
 .test-output-section h4,
 .test-source-section h4 {
-    color: #cccccc;
+    color: var(--text-strong);
     font-size: 1rem;
     margin-bottom: 0.75rem;
     display: flex;
@@ -401,9 +401,9 @@
 }
 
 .btn-copy {
-    background: #3c3c3c;
-    border: 1px solid #555;
-    color: #cccccc;
+    background: var(--control-bg);
+    border: 1px solid var(--border-strong);
+    color: var(--text-strong);
     padding: 0.4rem 0.75rem;
     border-radius: 4px;
     cursor: pointer;
@@ -415,14 +415,14 @@
 }
 
 .btn-copy:hover {
-    background: #505050;
-    border-color: #0e639c;
+    background: var(--control-hover);
+    border-color: var(--accent);
 }
 
 .btn-copy.copied {
-    background: #4ec9b0;
-    border-color: #4ec9b0;
-    color: #1e1e1e;
+    background: var(--teal);
+    border-color: var(--teal);
+    color: var(--bg);
 }
 
 .btn-copy.copied::before {
@@ -432,11 +432,11 @@
 .test-output,
 .test-source {
     flex: 1;
-    background: #1e1e1e;
-    border: 1px solid #3e3e42;
+    background: var(--bg);
+    border: 1px solid var(--border);
     border-radius: 4px;
     padding: 1rem;
-    color: #d4d4d4;
+    color: var(--text);
     font-family: 'Consolas', 'Courier New', monospace;
     font-size: 0.9rem;
     line-height: 1.5;
@@ -446,11 +446,11 @@
 }
 
 .test-output.success {
-    border-left: 3px solid #4ec9b0;
+    border-left: 3px solid var(--teal);
 }
 
 .test-output.error {
-    border-left: 3px solid #f48771;
+    border-left: 3px solid var(--red);
 }
 
 .test-loading,
@@ -458,11 +458,11 @@
 .test-error {
     text-align: center;
     padding: 2rem;
-    color: #6a6a6a;
+    color: var(--text-muted);
 }
 
 .test-error {
-    color: #f48771;
+    color: var(--red);
 }
 
 .test-summary {
@@ -471,7 +471,7 @@
 }
 
 .test-summary h3 {
-    color: #cccccc;
+    color: var(--text-strong);
     font-size: 1.3rem;
     margin-bottom: 1.5rem;
 }
@@ -484,39 +484,39 @@
 }
 
 .summary-stat {
-    background: #252526;
-    border: 1px solid #3e3e42;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
     border-radius: 6px;
     padding: 1.5rem;
     text-align: center;
 }
 
 .summary-stat.success {
-    border-color: #4ec9b0;
+    border-color: var(--teal);
 }
 
 .summary-stat.failed {
-    border-color: #f48771;
+    border-color: var(--red);
 }
 
 .stat-value {
     font-size: 2.5rem;
     font-weight: bold;
-    color: #d4d4d4;
+    color: var(--text);
     margin-bottom: 0.5rem;
 }
 
 .summary-stat.success .stat-value {
-    color: #4ec9b0;
+    color: var(--teal);
 }
 
 .summary-stat.failed .stat-value {
-    color: #f48771;
+    color: var(--red);
 }
 
 .stat-label {
     font-size: 0.9rem;
-    color: #6a6a6a;
+    color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 1px;
 }
@@ -528,8 +528,8 @@
 }
 
 .result-item {
-    background: #252526;
-    border: 1px solid #3e3e42;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
     border-radius: 4px;
     padding: 0.75rem 1rem;
     display: flex;
@@ -540,16 +540,16 @@
 }
 
 .result-item:hover {
-    background: #2d2d30;
-    border-color: #0e639c;
+    background: var(--bg-elev2);
+    border-color: var(--accent);
 }
 
 .result-item.success {
-    border-left: 3px solid #4ec9b0;
+    border-left: 3px solid var(--teal);
 }
 
 .result-item.failed {
-    border-left: 3px solid #f48771;
+    border-left: 3px solid var(--red);
 }
 
 .result-icon {
@@ -559,21 +559,21 @@
 }
 
 .result-item.success .result-icon {
-    color: #4ec9b0;
+    color: var(--teal);
 }
 
 .result-item.failed .result-icon {
-    color: #f48771;
+    color: var(--red);
 }
 
 .result-name {
     flex: 1;
-    color: #d4d4d4;
+    color: var(--text);
     font-size: 0.95rem;
 }
 
 .result-summary {
-    color: #6a6a6a;
+    color: var(--text-muted);
     font-size: 0.85rem;
 }
 
@@ -589,14 +589,14 @@
 .test-main::-webkit-scrollbar-track,
 .test-output::-webkit-scrollbar-track,
 .test-source::-webkit-scrollbar-track {
-    background: #1e1e1e;
+    background: var(--bg);
 }
 
 .test-list::-webkit-scrollbar-thumb,
 .test-main::-webkit-scrollbar-thumb,
 .test-output::-webkit-scrollbar-thumb,
 .test-source::-webkit-scrollbar-thumb {
-    background: #3e3e42;
+    background: var(--border);
     border-radius: 4px;
 }
 
@@ -604,5 +604,5 @@
 .test-main::-webkit-scrollbar-thumb:hover,
 .test-output::-webkit-scrollbar-thumb:hover,
 .test-source::-webkit-scrollbar-thumb:hover {
-    background: #555;
+    background: var(--border-strong);
 }

--- a/web/frontend/static/js/graph-visualizer.js
+++ b/web/frontend/static/js/graph-visualizer.js
@@ -274,7 +274,7 @@ class GraphVisualizer {
         const loopsContent = document.getElementById('loops-content');
         
         if (!this.loops || this.loops.length === 0) {
-            loopsContent.innerHTML = '<p style="padding: 1rem; color: #6a6a6a;">No loops detected</p>';
+            loopsContent.innerHTML = '<p style="padding: 1rem; color: var(--text-muted);">No loops detected</p>';
             return;
         }
         
@@ -289,38 +289,38 @@ class GraphVisualizer {
                      data-start-col="${loop.start_col}"
                      data-end-line="${loop.end_line}" 
                      data-end-col="${loop.end_col}"
-                     style="padding: 0.75rem; margin: 0.5rem 0; background: #252526; border: 1px solid #3e3e42; border-radius: 4px; cursor: pointer; transition: background 0.2s;">
+                     style="padding: 0.75rem; margin: 0.5rem 0; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 4px; cursor: pointer; transition: background 0.2s;">
                     <div class="loop-header" style="display: flex; justify-content: space-between; align-items: center;">
                         <div style="display: flex; align-items: center; gap: 0.75rem;">
-                            <strong style="color: #4ec9b0;">Loop ${loop.id}</strong>
-                            ${episodicityData ? `<span style="font-size: 0.85rem; color: ${episodicityData.is_episodic ? '#89d185' : '#f48771'}; font-weight: bold;">${episodicityData.is_episodic ? '✓ Episodic' : '✗ Non-episodic'}</span>` : ''}
+                            <strong style="color: var(--teal);">Loop ${loop.id}</strong>
+                            ${episodicityData ? `<span style="font-size: 0.85rem; color: ${episodicityData.is_episodic ? 'var(--green)' : 'var(--red)'}; font-weight: bold;">${episodicityData.is_episodic ? '✓ Episodic' : '✗ Non-episodic'}</span>` : ''}
                         </div>
                         ${episodicityData ? '<span class="loop-toggle">▼</span>' : ''}
                     </div>
-                    <div style="font-size: 0.85rem; color: #6a6a6a; margin-top: 0.25rem;">
+                    <div style="font-size: 0.85rem; color: var(--text-muted); margin-top: 0.25rem;">
                         Lines ${loop.start_line}:${loop.start_col} - ${loop.end_line}:${loop.end_col}
                     </div>
             `;
             
             // Add episodicity conditions if available
             if (episodicityData) {
-                html += '<div class="loop-conditions" style="margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid #3e3e42;">';
-                html += '<div style="font-size: 0.85rem; color: #cccccc; margin-bottom: 0.5rem; font-weight: bold;">Episodicity Conditions:</div>';
+                html += '<div class="loop-conditions" style="margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid var(--border);">';
+                html += '<div style="font-size: 0.85rem; color: var(--text-strong); margin-bottom: 0.5rem; font-weight: bold;">Episodicity Conditions:</div>';
                 
                 ['condition1', 'condition2', 'condition3', 'condition4'].forEach((condName, index) => {
                     const cond = episodicityData[condName];
                     if (cond) {
                         const satisfied = cond.satisfied;
                         const icon = satisfied ? '✓' : '✗';
-                        const color = satisfied ? '#89d185' : '#f48771';
+                        const color = satisfied ? 'var(--green)' : 'var(--red)';
                         const hasViolations = !satisfied && cond.violations && cond.violations.length > 0;
                         
                         html += `
-                            <div class="episodicity-condition" data-condition="${condName}" style="margin: 0.4rem 0; padding: 0.4rem; background: #1e1e1e; border-radius: 3px;">
+                            <div class="episodicity-condition" data-condition="${condName}" style="margin: 0.4rem 0; padding: 0.4rem; background: var(--bg); border-radius: 3px;">
                                 <div class="condition-header" style="display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;">
                                     <div style="display: flex; align-items: center; gap: 0.5rem;">
                                         <span style="color: ${color}; font-weight: bold; min-width: 20px;">${icon}</span>
-                                        <span style="color: #d4d4d4; font-size: 0.85rem;">Condition ${index + 1}</span>
+                                        <span style="color: var(--text); font-size: 0.85rem;">Condition ${index + 1}</span>
                                     </div>
                                     ${hasViolations ? '<span class="condition-toggle">▼</span>' : ''}
                                 </div>
@@ -333,7 +333,7 @@ class GraphVisualizer {
                                 const violationType = violation[0];
                                 const violationDetails = violation[1];
                                 
-                                html += `<div style="font-size: 0.8rem; color: #f48771; margin: 0.2rem 0;">`;
+                                html += `<div style="font-size: 0.8rem; color: var(--red); margin: 0.2rem 0;">`;
                                 
                                 if (Array.isArray(violationDetails)) {
                                     const [reason, register, span] = violationDetails;
@@ -406,12 +406,12 @@ class GraphVisualizer {
                 );
                 
                 // Visual feedback on the loop item
-                item.style.background = '#2d2d30';
+                item.style.background = 'var(--bg-elev2)';
             });
             
             item.addEventListener('mouseleave', () => {
                 this.clearSourceHighlight();
-                item.style.background = '#252526';
+                item.style.background = 'var(--bg-elev)';
             });
         });
     }
@@ -425,7 +425,7 @@ class GraphVisualizer {
         const assertionsContent = document.getElementById('assertions-content');
         
         if (!this.assertionResults) {
-            assertionsContent.innerHTML = '<p style="padding: 1rem; color: #6a6a6a;">No assertion results available.</p>';
+            assertionsContent.innerHTML = '<p style="padding: 1rem; color: var(--text-muted);">No assertion results available.</p>';
             return;
         }
         
@@ -522,7 +522,7 @@ class GraphVisualizer {
                 html += '</div>';
             });
         } else {
-            html += '<p style="padding: 1rem; color: #6a6a6a;">No assertion instances to display.</p>';
+            html += '<p style="padding: 1rem; color: var(--text-muted);">No assertion instances to display.</p>';
         }
         
         html += '</div>';
@@ -543,7 +543,7 @@ class GraphVisualizer {
             
             // Visual feedback on hover
             item.addEventListener('mouseenter', () => {
-                item.style.background = '#2d2d30';
+                item.style.background = 'var(--bg-elev2)';
             });
             
             item.addEventListener('mouseleave', () => {
@@ -562,7 +562,7 @@ class GraphVisualizer {
         const uafContent = document.getElementById('uaf-content');
 
         if (!this.uafResults || this.uafResults.length === 0) {
-            uafContent.innerHTML = '<p style="padding: 1rem; color: #6a6a6a;">No use-after-free violations found.</p>';
+            uafContent.innerHTML = '<p style="padding: 1rem; color: var(--text-muted);">No use-after-free violations found.</p>';
             return;
         }
 
@@ -588,12 +588,12 @@ class GraphVisualizer {
 
             html += `
                 <div class="uaf-item" data-data-index="${dataIndex}"
-                     style="padding: 0.75rem; margin: 0.5rem 0; background: #2a1a1a; border: 1px solid #6b2020; border-radius: 4px; cursor: pointer; transition: background 0.2s;">
+                     style="padding: 0.75rem; margin: 0.5rem 0; background: var(--red-bg); border: 1px solid var(--red-border); border-radius: 4px; cursor: pointer; transition: background 0.2s;">
                     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.4rem;">
-                        <strong style="color: #ff6b6b;">&#9888; Execution ${execId}</strong>
-                        <span style="font-size: 0.75rem; color: #6a6a6a;">${uaf.length} pair${uaf.length !== 1 ? 's' : ''}</span>
+                        <strong style="color: var(--red-bright);">&#9888; Execution ${execId}</strong>
+                        <span style="font-size: 0.75rem; color: var(--text-muted);">${uaf.length} pair${uaf.length !== 1 ? 's' : ''}</span>
                     </div>
-                    <div style="font-size: 0.82rem; color: #d4a0a0; line-height: 1.6;">
+                    <div style="font-size: 0.82rem; color: var(--red-text); line-height: 1.6;">
                         ${pairLabels.map(l => `<div style="font-family: monospace;">${this.escapeHtml(l)}</div>`).join('')}
                     </div>
                 </div>
@@ -611,8 +611,8 @@ class GraphVisualizer {
                     this.navigateTo(dataIndex);
                 }
             });
-            item.addEventListener('mouseenter', () => { item.style.background = '#3a1f1f'; });
-            item.addEventListener('mouseleave', () => { item.style.background = '#2a1a1a'; });
+            item.addEventListener('mouseenter', () => { item.style.background = 'var(--red-bg-hover)'; });
+            item.addEventListener('mouseleave', () => { item.style.background = 'var(--red-bg)'; });
         });
     }
 
@@ -1062,7 +1062,7 @@ class GraphVisualizer {
 
             const lbl = document.createElement('span');
             lbl.textContent = rel;
-            lbl.style.color = '#d4d4d4';
+            lbl.style.color = 'var(--text)';
             lbl.style.fontSize = '13px';
             lbl.style.cursor = 'pointer';
 
@@ -1124,9 +1124,9 @@ class GraphVisualizer {
         if (!data) {
             document.getElementById('predicates').textContent = '⊤';
             document.getElementById('has-uaf').textContent = 'N/A';
-            document.getElementById('has-uaf').style.color = '#d4d4d4';
+            document.getElementById('has-uaf').style.color = 'var(--text)';
             document.getElementById('has-unbounded-deref').textContent = 'N/A';
-            document.getElementById('has-unbounded-deref').style.color = '#d4d4d4';
+            document.getElementById('has-unbounded-deref').style.color = 'var(--text)';
             return;
         }
 
@@ -1172,31 +1172,31 @@ class GraphVisualizer {
 
               console.log('UAF pairs formatted:', uafPairs);
               uafSpan.textContent = uafPairs;
-              uafSpan.style.color = '#ff6b6b';
+              uafSpan.style.color = 'var(--red-bright)';
           } else {
               // No UAF in this execution
               uafSpan.textContent = 'No';
-              uafSpan.style.color = '#89d185';
+              uafSpan.style.color = 'var(--green)';
           }
 
           // Handle unbounded deref
           const unboundedSpan = document.getElementById('has-unbounded-deref');
           if (ub_reasons.unbounded_deref) {
               unboundedSpan.textContent = 'Yes';
-              unboundedSpan.style.color = '#ff6b6b';
+              unboundedSpan.style.color = 'var(--red-bright)';
           } else {
               unboundedSpan.textContent = 'No';
-              unboundedSpan.style.color = '#89d185';
+              unboundedSpan.style.color = 'var(--green)';
           }
         } else {
             // No undefined behaviour data - reset to "No" for executions
             const uafSpan = document.getElementById('has-uaf');
             uafSpan.textContent = 'No';
-            uafSpan.style.color = '#89d185';
+            uafSpan.style.color = 'var(--green)';
 
             const unboundedSpan = document.getElementById('has-unbounded-deref');
             unboundedSpan.textContent = 'No';
-            unboundedSpan.style.color = '#89d185';
+            unboundedSpan.style.color = 'var(--green)';
         }
     }
 
@@ -1271,9 +1271,9 @@ class GraphVisualizer {
         // Clear execution info fields
         document.getElementById('predicates').textContent = '⊤';
         document.getElementById('has-uaf').textContent = 'N/A';
-        document.getElementById('has-uaf').style.color = '#d4d4d4';
+        document.getElementById('has-uaf').style.color = 'var(--text)';
         document.getElementById('has-unbounded-deref').textContent = 'N/A';
-        document.getElementById('has-unbounded-deref').style.color = '#d4d4d4';
+        document.getElementById('has-unbounded-deref').style.color = 'var(--text)';
 
         // Clear graph stats
         document.getElementById('node-count').textContent = '0';
@@ -1354,7 +1354,7 @@ class GraphVisualizer {
                 document.getElementById('status').textContent = 'Complete';
                 // If no UAF found by the end, show a clean "none found" message
                 if (this.uafResults.length === 0) {
-                    document.getElementById('uaf-content').innerHTML = '<p style="padding: 1rem; color: #89d185;">&#10003; No use-after-free found.</p>';
+                    document.getElementById('uaf-content').innerHTML = '<p style="padding: 1rem; color: var(--green);">&#10003; No use-after-free found.</p>';
                 }
                 abortController.abort();
                 document.getElementById('action-btn').disabled = false;
@@ -1534,7 +1534,7 @@ class GraphVisualizer {
 
     showError(message) {
         document.getElementById('empty-state').innerHTML = 
-            `<div style="color: #f48771; padding: 2rem; text-align: center;">
+            `<div style="color: var(--red); padding: 2rem; text-align: center;">
                 <p>${message}</p>
                 <p style="margin-top: 1rem; font-size: 0.9rem;">Check the log below for details</p>
             </div>`;


### PR DESCRIPTION
## Summary

Adds a light/dark theme toggle to the MoRDor web UI. The app was previously hardcoded to a dark palette; this converts it to a CSS-variable-based theming system.

- **Palette → CSS variables**: introduced a `:root` variable palette (dark, default) plus a `:root[data-theme="light"]` override, and replaced hardcoded colors across `mordor.css`, `test-runner.css`, the JS-injected analysis sidebar in `graph-visualizer.js`, and the standalone `help.html`.
- **Toggle button** in the header (🌙/☀️) that flips `data-theme` on `<html>`, persists the choice to `localStorage`, and updates its icon.
- **No flash on load**: an early inline `<head>` script applies the saved theme (falling back to the OS `prefers-color-scheme`) before first paint.
- **Help page** gets its own toggle and honors the same saved theme.
- Primary buttons use a dedicated `--on-accent` variable so their text stays white-on-blue in both themes (fixes the "Visualize" button being unreadable in light mode).
- Cytoscape/canvas graph colors were intentionally left untouched — CSS variables don't resolve on the graph canvas, and those colors read fine on both backgrounds.

## Testing

Built and launched the web server, then drove Chrome via the DevTools Protocol to screenshot both themes:
- Light mode renders light panels with dark text at good contrast.
- Dark mode is unchanged from before.
- Theme persists across reloads and across the main/help pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)